### PR TITLE
Improved k3d container configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,41 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+FROM rancher/k3d:v4.4.6-dind
 
-FROM  ubuntu:bionic
-
+RUN curl -fsSL -o /get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+RUN chmod 700 /get_helm.sh
+RUN /get_helm.sh && rm /get_helm.sh
 RUN mkdir -p /app
 
 COPY health_check.sh /app/health_check.sh
 COPY initiate_kubernetes_cluster.sh /app/initiate_kubernetes_cluster.sh
 COPY verify_if_deployed_service_is_ready.sh /app/verify_if_deployed_service_is_ready.sh
 
-RUN apt-get update && apt-get install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common wget -y
-
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
-RUN apt-get update
-RUN apt-get install kubectl=1.20.1-00 -y
-RUN curl https://baltocdn.com/helm/signing.asc | apt-key add -
-RUN echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
-RUN apt-get update
-RUN apt-get install helm -y
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-       $(lsb_release -cs) \
-       stable"
-
-RUN apt-get update
-RUN apt-get install docker-ce docker-ce-cli containerd.io -y
-
-HEALTHCHECK CMD ["sh", "-c", "/app/health_check.sh /app/"]
-CMD ["sh", "-c", "/app/initiate_kubernetes_cluster.sh \"${CLUSTER_NAME}\" \"${CLUSTER_API_PORT}\" \
+HEALTHCHECK CMD ["bash", "-c", "/app/health_check.sh /app/"]
+CMD ["bash", "-c", "/app/initiate_kubernetes_cluster.sh \"${CLUSTER_NAME}\" \"${CLUSTER_API_PORT}\" \
 \"${LOAD_BALANCER_PORTS}\" \"${SECRET_ENVIRONMENT}\" \"${SECRETS_ENVIRONMENT_VARIABLES}\" \
 \"${CREATE_CONFIG_MAPS_VOLUMES_FROM_FILES_COMMAND}\" \"${DEPLOY_YAML_FILES_PATH}\" \
 && tail -f /dev/null"]

--- a/health_check.sh
+++ b/health_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2021 JSquad AB
@@ -20,23 +20,28 @@ SCRIPT_PATH=${1:-'./'}
 
 PODS=$(kubectl get pods | awk 'FNR > 1 {print $1}' | xargs)
 
+while [ -z "$PODS" ]; do
+  PODS=$(kubectl get pods | awk 'FNR > 1 {print $1}' | xargs)
+  sleep 5
+done
+
 for pod in $PODS;
 do
   STATUS=$(kubectl get pod "$pod" | awk 'FNR > 1 {print $3}')
   if [ "$STATUS" == "Running" ];
   then :
-    command="kubectl describe pod ${pod} | grep -Po 'ContainersReady.*True' | head -1 | grep -Po 'True'"
+    command="kubectl describe pod ${pod} | grep -o 'ContainersReady.*True' | head -1 | grep -o 'True'"
     "$SCRIPT_PATH"verify_if_deployed_service_is_ready.sh "$pod" "$command"
   fi
 done
 
-DEPLOYMENTS=$(kubectl get deployments| awk 'FNR > 1 {print $1}' | xargs)
+DEPLOYMENTS=$(kubectl get deployments | awk 'FNR > 1 {print $1}' | xargs)
 
 for deployment in $DEPLOYMENTS;
 do
-    command="kubectl describe deployment ${deployment} | grep -Po 'Available.*True' | head -1 | grep -Po 'True'"
+    command="kubectl describe deployment ${deployment} | grep -o 'Available.*True' | head -1 | grep -o 'True'"
     "$SCRIPT_PATH"verify_if_deployed_service_is_ready.sh "$pod" "$command"
 
-    command="kubectl describe deployment ${deployment} | grep -Po 'Progressing.*True' | head -1 | grep -Po 'True'"
+    command="kubectl describe deployment ${deployment} | grep -o 'Progressing.*True' | head -1 | grep -o 'True'"
     "$SCRIPT_PATH"verify_if_deployed_service_is_ready.sh "$pod" "$command"
 done

--- a/verify_if_deployed_service_is_ready.sh
+++ b/verify_if_deployed_service_is_ready.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2021 JSquad AB


### PR DESCRIPTION
Improved k3d container configuration by replacing Ubuntu bionic
distro with k3d docker in docker image to simplify maintainability
by removing unnessesary dependencies to Docker, kubectl etc since
it's included in the base k3d-dind image.

Updated Bash shebang to be portable between different unix systems.

Added pod loop logic to verify that pods has been created by
Kubernetes default namespace before checking their health state by
related health check logic.

Replaced Shell with Bash command for Dockerfile CMD setup.

Set ingress-nginx helm package version to 3.34.

Updated grep health check logic to be compatible in a BusyBox
container environment.

Updated initiate_kubernetes_cluster.sh to be less dependent of specific